### PR TITLE
Add stable custom null type

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -16,6 +16,7 @@ export const parser = (args: Array<string>) => {
     .option('inputFile', { type: 'string', demandOption: true })
     .option('outputDir', { type: 'string', demandOption: true })
     .option('strict', { type: 'boolean', default: false })
+    .option('maskNull', { type: 'boolean', default: false })
     .option('emit', { type: 'boolean', default: true })
     .option('base', { type: 'string', default: '' })
     .option('import', { type: 'string', array: true, default: [] })


### PR DESCRIPTION
The standard TypeScript type `null` tends to turn into `never` easily when combined with branding. See related StackOverflow [thread](https://stackoverflow.com/questions/65701675/is-there-any-way-to-make-two-null-values-distinguishable-in-typescript-at-type-l) for details. This PR adds an option to replace the standard `null` type with a custom type `Null`. Replacing the type won't affect the runtime value. Javascript code should still see the value `null` since we are only changing the type.