### PR TITLE
Fix handling of multi line title and description

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "io-ts-from-json-schema",
-  "version": "0.0.24",
+  "version": "0.0.25",
   "description": "Iotsfjs is a static code generation utility used for converting json schema files into static TypeScript types and io-ts runtime validators.",
   "license": "MIT",
   "keywords": [

--- a/src/iotsfjs.ts
+++ b/src/iotsfjs.ts
@@ -1121,8 +1121,8 @@ export type Null = t.TypeOf<typeof Null>
       staticType,
       runtimeType,
     } = def;
-    yield `// ${title}`;
-    yield `// ${description}`;
+    yield* title.split('\n').map((line) => `// ${line}`);
+    yield* description.split('\n').map((line) => `// ${line}`);
     yield staticType;
     yield runtimeType;
     if (examples.length > 0) {


### PR DESCRIPTION
This pull request fixes #79 by generating a separate line comment for each line of JSON schema `title` and `description`. This approach has the benefit that existing non-multi-line conversions won't change as a result.