### PR TITLE
Remove broken oneOf keyword support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "io-ts-from-json-schema",
-  "version": "0.0.25",
+  "version": "0.0.26",
   "description": "Iotsfjs is a static code generation utility used for converting json schema files into static TypeScript types and io-ts runtime validators.",
   "license": "MIT",
   "keywords": [

--- a/src/iotsfjs.ts
+++ b/src/iotsfjs.ts
@@ -161,7 +161,6 @@ export type Null = t.TypeOf<typeof Null>
     'additionalProperties',
     'allOf',
     'anyOf',
-    'oneOf',
     'enum',
     'const',
     'items',
@@ -753,14 +752,6 @@ export type Null = t.TypeOf<typeof Null>
     return [];
   }
 
-  function fromOneOf(schema: JSONSchema7): [gen.TypeReference] | [] {
-    if ('oneOf' in schema && typeof schema.oneOf !== 'undefined') {
-      const combinators = schema.oneOf.map((s) => fromSchema(s));
-      return genUnionCombinator(combinators);
-    }
-    return [];
-  }
-
   function fromSchema(schema: JSONSchema7Definition, isRoot = false): gen.TypeReference {
     if (typeof schema === 'boolean') {
       imps.add("import * as t from 'io-ts';");
@@ -797,7 +788,6 @@ export type Null = t.TypeOf<typeof Null>
       ...fromConst(schema),
       ...fromAllOf(schema),
       ...fromAnyOf(schema),
-      ...fromOneOf(schema),
     ];
     if (combinators.length > 1) {
       return gen.intersectionCombinator(combinators);


### PR DESCRIPTION
This PR removes broken support for `oneOf` keyword. It has never worked according to specification.